### PR TITLE
Change wolf ambient subtitle

### DIFF
--- a/Text Fixes/assets/minecraft/lang/en_us.json
+++ b/Text Fixes/assets/minecraft/lang/en_us.json
@@ -3767,7 +3767,7 @@
   "subtitles.entity.wither_skeleton.ambient": "Wither Skeleton rattles",
   "subtitles.entity.wither_skeleton.death": "Wither Skeleton dies",
   "subtitles.entity.wither_skeleton.hurt": "Wither Skeleton hurts",
-  "subtitles.entity.wolf.ambient": "Wolf pants",
+  "subtitles.entity.wolf.ambient": "Wolf barks",
   "subtitles.entity.wolf.death": "Wolf dies",
   "subtitles.entity.wolf.growl": "Wolf growls",
   "subtitles.entity.wolf.hurt": "Wolf hurts",


### PR DESCRIPTION
The sound event entity.wolf.ambient is of a dog barking, not panting, so this subtitle didn't make sense. However, the subtitle itself is referenced by the panting and whining sound events as well, which is also a vanilla issue which I've already fixed over at my own resource pack (since it requires editing sounds.json and can't be achieved by simply editing lang files alone): https://github.com/muzikbike/VanillaFixes